### PR TITLE
Fixed MongoDB key with dots issue

### DIFF
--- a/flask-be/services/database/database.py
+++ b/flask-be/services/database/database.py
@@ -23,8 +23,7 @@ To use these functions, ensure that the database URI is correctly specified in t
 
 
 from typing import Optional
-from datamodels import FileConfluenceOutput, RepositoryConfluenceOutput
-from datamodels import json_to_respsitory_confluence_output, json_to_file_confluence_output
+from datamodels import RepositoryConfluenceOutput, FileConfluenceOutput, database_json_to_respsitory_confluence_output
 
 from pymongo import MongoClient
 from pymongo.results import InsertOneResult
@@ -50,7 +49,7 @@ def get_documentation_by_url(repository_url: str) -> Optional[RepositoryConfluen
 
     result = collection.find_one({"repository_url": repository_url}, {"_id": 0})
     if result:
-        return json_to_respsitory_confluence_output(result)
+        return database_json_to_respsitory_confluence_output(result)
     return None
 
 
@@ -85,11 +84,15 @@ def add_file_to_repository(repository_url: str, file_confluence_output: FileConf
     - The result of the update operation.
     """
     update_query = {"repository_url": repository_url}
+    file_data_key = "files." + file_confluence_output.file_path.replace('.', '_')  # Replace dots with underscores
+    print(file_data_key)
     file_data = {
-        f"files.{file_confluence_output.file_path}": file_confluence_output.model_dump()
+        "$set": {
+            file_data_key: file_confluence_output.model_dump()
+        }
     }
 
-    result = collection.update_one(update_query, {"$set": file_data}, upsert=True)
+    result = collection.update_one(update_query, file_data, upsert=True)
     return result
 
 def get_file_documentation(repository_url: str, file_path: str) -> Optional[FileConfluenceOutput]:
@@ -105,10 +108,9 @@ def get_file_documentation(repository_url: str, file_path: str) -> Optional[File
     """
     result = collection.find_one({"repository_url": repository_url})
     if result:
-        file_data = result.get("files", {}).get(file_path)
+        file_data = result.get("files", {}).get(file_path.replace('.', '_'))
         if file_data:
-            return json_to_file_confluence_output(file_data)
-
+            return FileConfluenceOutput(**file_data)
     return None
 
 
@@ -124,15 +126,11 @@ def update_documentation_by_file(repository_url: str, file_path: str, new_data: 
     Returns:
     - The result of the update operation.
     """
-    # Convert the FileConfluenceOutput object to a dictionary
     new_data_dict = new_data.model_dump()
-
-    # Construct the update query
+    file_path = file_path.replace('.', '_')
     update_query = {
         f"files.{file_path}": {k: v for k, v in new_data_dict.items() if k != 'file_path'}
     }
-
-    # Perform the update operation
     result = collection.update_one(
         {"repository_url": repository_url, f"files.{file_path}": {"$exists": True}},
         {"$set": update_query}
@@ -166,6 +164,6 @@ def delete_file_from_documentation(repository_url: str, file_key: str) -> Update
     """
     result = collection.update_one(
         {"repository_url": repository_url},
-        {"$unset": {f"files.{file_key}": ""}}
+        {"$unset": {f"files.{file_key.replace('.', '_')}": ""}}
     )
     return result

--- a/flask-be/services/database/datamodels.py
+++ b/flask-be/services/database/datamodels.py
@@ -27,7 +27,14 @@ class RepositoryConfluenceOutput(BaseModel):
     created_at: datetime = Field(description="Time when the repository was created", default_factory=datetime.now)
     last_modified: datetime = Field(description="Time when the repository was last modified", default_factory=datetime.now)
 
-def json_to_respsitory_confluence_output(json_data: dict) -> RepositoryConfluenceOutput:
+def external_json_to_respsitory_confluence_output(json_data: dict) -> RepositoryConfluenceOutput:
+    formatted_json = {}
+    formatted_json["repository_url"] = json_data["repository_url"]
+    formatted_json["repository_name"] = json_data["repository_name"]
+    formatted_json["repository_summary"] = json_data.get("repository_summary", "")
+    formatted_json["confluence_id"] = json_data.get("confluence_id", "")
+    formatted_json["current_status"] = json_data.get("current_status", "Not started")
+    formatted_json["files"] = {}
     files = json_data["files"]
     for file_path, file_data in files.items():
         file_data["file_path"] = file_path
@@ -37,11 +44,11 @@ def json_to_respsitory_confluence_output(json_data: dict) -> RepositoryConfluenc
             packages[package_name] = PackageDetail(**package_data)
         for function_name, function_data in functions.items():
             functions[function_name] = FunctionDetail(**function_data)
-        files[file_path] = FileConfluenceOutput(**file_data)
-    json_data["files"] = files
-    return RepositoryConfluenceOutput(**json_data)
+        replacement_file_name = file_path.replace(".", "_")
+        formatted_json["files"][replacement_file_name]= FileConfluenceOutput(**file_data)
+    return RepositoryConfluenceOutput(**formatted_json)
 
-def json_to_file_confluence_output(json_data: dict) -> FileConfluenceOutput:
+def external_json_to_file_confluence_output(json_data: dict) -> FileConfluenceOutput:
     formatted_json = {}
     file_name = next(iter(json_data.keys()))
     file = json_data[file_name]
@@ -57,3 +64,41 @@ def json_to_file_confluence_output(json_data: dict) -> FileConfluenceOutput:
     print(formatted_json)
     return FileConfluenceOutput(**formatted_json)
 
+def database_json_to_respsitory_confluence_output(json_data: dict) -> RepositoryConfluenceOutput:
+    formatted_json = {}
+    formatted_json["repository_url"] = json_data["repository_url"]
+    formatted_json["repository_name"] = json_data["repository_name"]
+    formatted_json["repository_summary"] = json_data.get("repository_summary", "")
+    formatted_json["confluence_id"] = json_data.get("confluence_id", "")
+    formatted_json["current_status"] = json_data.get("current_status", "Not started")
+    formatted_json["files"] = {}
+    files = json_data["files"]
+    for file_path, file_data in files.items():
+        replacement_file_name = file_path.replace("_", ".")
+        file_data["file_path"] = replacement_file_name
+        print("Now the file path is", file_data["file_path"])
+        packages = file_data.get("packages", {})
+        functions = file_data.get("functions", {})
+        for package_name, package_data in packages.items():
+            packages[package_name] = PackageDetail(**package_data)
+        for function_name, function_data in functions.items():
+            functions[function_name] = FunctionDetail(**function_data)
+        replacement_file_name = file_path.replace("_", ".")
+        formatted_json["files"][replacement_file_name]= FileConfluenceOutput(**file_data)
+    return RepositoryConfluenceOutput(**formatted_json)
+
+def database_json_to_file_confluence_output(json_data: dict) -> FileConfluenceOutput:
+    formatted_json = {}
+    file_name = next(iter(json_data.keys()))
+    file = json_data[file_name]
+    formatted_json["file_path"] = file_name
+    packages = file.get("packages", {})
+    functions = file.get("functions", {})
+    for package_name, package_data in packages.items():
+        packages[package_name] = PackageDetail(**package_data)
+    for function_name, function_data in functions.items():
+        functions[function_name] = FunctionDetail(**function_data)
+    formatted_json["packages"] = packages
+    formatted_json["functions"] = functions
+    print(formatted_json)
+    return FileConfluenceOutput(**formatted_json)


### PR DESCRIPTION
MongoDB does not accept keys with dots in them.
Caution: Data in DB will not be consistent with what you get in Backend and Frontend. (file keys with dots will be replaced with _)